### PR TITLE
Fix leftover debug strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ gmlift-InternalDate: 1743014808000
 
 The export preserves all original email headers (such as Delivered-To, Received, etc.) while adding these Gmail-specific headers to ensure no metadata is lost during the export process.
 
-TEST
-
 ## License
 
 Apache-2.0

--- a/tests/util/dates.test.ts
+++ b/tests/util/dates.test.ts
@@ -113,8 +113,6 @@ describe('dates utility', () => {
         it('gets start of month correctly', () => {
             const result = dates.startOfMonth(TEST_DATE);
             // Don't test exact day/hour values which can be affected by timezone
-            console.log("FUCK: " + result.toISOString());
-            console.log("FUCK: " + TEST_DATE.toISOString());
 
             expect(dates.format(result, 'MM')).toBe(dates.format(TEST_DATE, 'MM'));
             expect(dates.format(result, 'YYYY')).toBe(dates.format(TEST_DATE, 'YYYY'));


### PR DESCRIPTION
## Summary
- remove leftover console log statements in date tests
- remove stray TEST placeholder in README

## Testing
- `npm test` *(fails: jest not found)*