### PR TITLE
Fix From header handling

### DIFF
--- a/src/gmail/MessageWrapper.ts
+++ b/src/gmail/MessageWrapper.ts
@@ -21,9 +21,6 @@ export default class MessageWrapper {
             throw new Error('Message is missing Date header');
         }
         const from = this.findHeader(headers, 'From');
-        if (!from) {
-            throw new Error('Message is missing From header');
-        }
         const messageId = this.findHeader(headers, 'Message-ID');
         const to = this.findHeader(headers, 'To');
         const subject = this.findHeader(headers, 'Subject');
@@ -52,7 +49,7 @@ export default class MessageWrapper {
         return header?.value || undefined;
     }
     // Getters for headers
-    get from(): string { return this.headers.from; }
+    get from(): string | undefined { return this.headers.from; }
     get to(): string | undefined { return this.headers.to; }
     get subject(): string | undefined { return this.headers.subject; }
     get date(): string { return this.headers.date!; }

--- a/src/gmailExport.ts
+++ b/src/gmailExport.ts
@@ -87,6 +87,14 @@ export const create = (gmliftConfig: gmliftConfig, api: GmailApiInstance, operat
             return;
         }
 
+        // Ensure the message contains a From header before continuing
+        const hasFrom = messageMetadata.payload?.headers?.some(h => h.name === 'From');
+        if (!hasFrom) {
+            logger.warn('Skipping message %s due to missing From header', messageId);
+            errorCount++;
+            return;
+        }
+
         try {
             // Wrap the message metadata in a wrapper class to reduce the amount of code needed to access the message metadata
             const wrappedMessage = new MessageWrapper(messageMetadata);

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export interface GmailLabel {
 
 // Type for the headers we care about
 export interface MessageHeaders {
-    from: string;
+    from?: string;
     to?: string;
     subject?: string;
     date: string;

--- a/tests/gmail/MessageWrapper.test.ts
+++ b/tests/gmail/MessageWrapper.test.ts
@@ -42,12 +42,13 @@ describe('MessageWrapper', () => {
             expect(() => new MessageWrapper(invalidMessage)).toThrow('Message is missing Date header');
         });
 
-        it('should throw error when From header is missing', () => {
+        it('should not throw error when From header is missing', () => {
             const invalidHeaders = mockHeaders.filter(h => h.name !== 'From');
             const invalidMessage: gmail_v1.Schema$Message = {
                 payload: { headers: invalidHeaders }
             };
-            expect(() => new MessageWrapper(invalidMessage)).toThrow('Message is missing From header');
+            const wrapper = new MessageWrapper(invalidMessage);
+            expect(wrapper.from).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary
- make `MessageHeaders.from` optional
- allow `MessageWrapper` to handle messages without a From header
- warn and skip messages missing From during export
- adjust unit tests for new From header handling

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails to install pnpm due to missing network access)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*