### PR TITLE
Fix ENAMETOOLONG by truncating email subjects

### DIFF
--- a/src/gmail/attachment.ts
+++ b/src/gmail/attachment.ts
@@ -2,6 +2,7 @@ import { gmail_v1 } from 'googleapis';
 import * as path from 'path';
 import * as Dates from '../util/dates';
 import * as Storage from '../util/storage';
+import { sanitizeFilename as utilSanitizeFilename } from '../util/filenames';
 import {
     DEFAULT_BINARY_TO_TEXT_ENCODING,
     DATE_FORMAT_DAY,
@@ -12,9 +13,10 @@ import {
     DEFAULT_CHARACTER_ENCODING,
 } from '../constants';
 import { Instance as GmailApiInstance } from './api.d';
+
+// Re-export sanitizeFilename for backwards compatibility with tests
 export function sanitizeFilename(filename: string): string {
-    // Replace characters that are invalid in filenames
-    return filename.replace(/[<>:"/\\|?*]/g, '-');
+    return utilSanitizeFilename(filename);
 }
 
 export function getAttachmentFilePath(baseDir: string, date: Date, subject: string, attachmentName: string, timezone: string): string {

--- a/src/gmailExport.ts
+++ b/src/gmailExport.ts
@@ -11,6 +11,7 @@ import { getLogger } from './logging';
 import { DateRange, gmliftConfig } from 'types';
 import * as Dates from './util/dates';
 import * as Storage from './util/storage';
+import { safeSubject } from './util/filenames';
 
 
 async function getEmailFilePath(
@@ -26,7 +27,8 @@ async function getEmailFilePath(
     const date = dates.date(dateHeader);
 
     const dirPath = await operator.constructOutputDirectory(date);
-    const baseFilename = await operator.constructFilename(date, 'email', messageId, { subject });
+    const sanitizedSubject = safeSubject(subject);
+    const baseFilename = await operator.constructFilename(date, 'email', messageId, { subject: sanitizedSubject });
 
     await storage.createDirectory(dirPath);
 

--- a/src/util/filenames.ts
+++ b/src/util/filenames.ts
@@ -1,0 +1,22 @@
+import crypto from 'node:crypto';
+
+/** Replace characters invalid in filenames with dashes */
+export function sanitizeFilename(filename: string): string {
+    return filename.replace(/[<>:"/\\|?*]/g, '-');
+}
+
+/**
+ * Sanitize and shorten an email subject for use in filenames.
+ * If the sanitized subject exceeds `maxLength`, it is truncated and a short
+ * hash of the original subject is appended to help preserve uniqueness.
+ */
+export function safeSubject(subject: string, maxLength = 100): string {
+    const sanitized = sanitizeFilename(subject);
+    if (sanitized.length <= maxLength) {
+        return sanitized;
+    }
+
+    const hash = crypto.createHash('sha1').update(sanitized).digest('hex').slice(0, 8);
+    const truncated = sanitized.slice(0, maxLength - 9); // leave space for '-' + hash
+    return `${truncated}-${hash}`;
+}

--- a/tests/util/filenames.test.ts
+++ b/tests/util/filenames.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import { safeSubject, sanitizeFilename } from '../../src/util/filenames.js';
+
+describe('filename utilities', () => {
+    test('sanitizeFilename replaces invalid characters', () => {
+        expect(sanitizeFilename('a/b:c*?')).toBe('a-b-c--');
+    });
+
+    test('safeSubject truncates long subjects and appends hash', () => {
+        const long = 'a'.repeat(150);
+        const result = safeSubject(long, 50);
+        expect(result.length).toBeLessThanOrEqual(50);
+        // should end with dash followed by 8 hex chars
+        expect(/-[0-9a-f]{8}$/.test(result)).toBe(true);
+    });
+
+    test('safeSubject returns sanitized subject when short', () => {
+        const result = safeSubject('Short Subject');
+        expect(result).toBe('Short Subject');
+    });
+});


### PR DESCRIPTION
## Summary
- add filename helpers for sanitizing and truncating subjects
- re-export sanitizeFilename from attachment module
- use new safeSubject helper when constructing email filenames
- test filename helper functions

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails to fetch packages: EHOSTUNREACH)*