### PR TITLE
Handle emails missing Date header

### DIFF
--- a/src/gmail/MessageWrapper.ts
+++ b/src/gmail/MessageWrapper.ts
@@ -16,9 +16,18 @@ export default class MessageWrapper {
         if (!headers) {
             throw new Error('Message is missing headers');
         }
-        const date = this.findHeader(headers, 'Date');
+        let date = this.findHeader(headers, 'Date');
         if (!date) {
-            throw new Error('Message is missing Date header');
+            // Fallback to internalDate if available
+            if (message.internalDate) {
+                const ts = Number(message.internalDate);
+                if (!isNaN(ts)) {
+                    date = new Date(ts).toUTCString();
+                }
+            }
+            if (!date) {
+                throw new Error('Message is missing Date header');
+            }
         }
         const from = this.findHeader(headers, 'From');
         const messageId = this.findHeader(headers, 'Message-ID');

--- a/tests/gmail/MessageWrapper.test.ts
+++ b/tests/gmail/MessageWrapper.test.ts
@@ -34,7 +34,17 @@ describe('MessageWrapper', () => {
             expect(() => new MessageWrapper(invalidMessage)).toThrow('Message is missing headers');
         });
 
-        it('should throw error when Date header is missing', () => {
+        it('should fallback to internalDate when Date header is missing', () => {
+            const invalidHeaders = mockHeaders.filter(h => h.name !== 'Date');
+            const invalidMessage: gmail_v1.Schema$Message = {
+                payload: { headers: invalidHeaders },
+                internalDate: '1710801600000'
+            };
+            const wrapper = new MessageWrapper(invalidMessage);
+            expect(wrapper.date).toBe(new Date(1710801600000).toUTCString());
+        });
+
+        it('should throw error when Date header and internalDate are missing', () => {
             const invalidHeaders = mockHeaders.filter(h => h.name !== 'Date');
             const invalidMessage: gmail_v1.Schema$Message = {
                 payload: { headers: invalidHeaders }


### PR DESCRIPTION
## Summary
- gracefully recover when an email lacks a Date header
- adjust MessageWrapper tests for new fallback behaviour

## Testing
- `npm test` *(fails: jest not found)*